### PR TITLE
Added server-side SAD support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,7 +130,7 @@ dmypy.json
 
 model/*
 
-# Chime6 example
+# Chime6 ASR example
 final.mdl
 global_cmvn.stats
 HCLG.fst
@@ -153,3 +153,10 @@ ivector_extractor/
 conf/
 chime6_model/
 *.tar.gz 
+
+# Chime6 SAD system
+SAD_model/
+final.raw
+post_output.vec
+wav.scp
+*.wav

--- a/server/kaldigrpc/segment.py
+++ b/server/kaldigrpc/segment.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+import random
+
+from kaldi.util.table import SequentialMatrixReader
+from kaldigrpc.config import SadConfig
+
+from kaldi.util.options import ParseOptions
+from kaldi.util.table import SequentialWaveReader
+from kaldi.online2 import (OnlineEndpointConfig,
+                           OnlineIvectorExtractorAdaptationState,
+                           OnlineNnetFeaturePipelineConfig,
+                           OnlineNnetFeaturePipelineInfo,
+                           OnlineNnetFeaturePipeline,
+                           OnlineSilenceWeighting)
+
+chunk_size = 300000
+
+
+class KaldiSegmentor:
+
+    def __init__(self, cfg: SadConfig, args):
+        self.config = cfg
+        self.wav = args.wav
+
+    @classmethod
+    def register(cls, po: ParseOptions):
+        po.register_str("wav", "", "Path to wav file for decoding")
+        po.register_bool("streaming", False, "Use streaming online segmentor")
+
+    def segment(self):
+
+        f = open(self.config.model.wavscp, "w")
+        f.write(str(random.randrange(100000, 1000000)) + " " + self.wav + "\n")
+        f.close()
+
+        with SequentialMatrixReader(self.config.feats_rspec) as f, open("segments", "w") as s:
+            for key, feats in f:
+                out = self.config.sad.segment(feats)
+                segments, stats = self.config.seg.process(out["alignment"])
+                self.config.seg.write(key, segments, s)
+                print("segments:", segments, flush=True)
+                print("stats:", stats, flush=True)
+        print("global stats:", self.config.seg.stats, flush=True)
+
+def transcribe_wav():
+    po = ParseOptions(
+        """SAD using Kaldi.
+        Usage:
+            python segment.py --model-dir=/model/ --wav=/path/to/test.wav
+        """
+    )
+
+    KaldiSegmentor.register(po)
+    config, args = SadConfig.parse_options(po)
+    sad = KaldiSegmentor(config, args)
+    sad.segment()
+
+
+if __name__ == "__main__":
+    transcribe_wav()

--- a/server/scripts/setup_SAD.sh
+++ b/server/scripts/setup_SAD.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+INITIAL_WORKING_DIRECTORY=$(pwd)
+cd "$(dirname "$0")"
+
+# create SAD model tree structure
+mkdir ../SAD_model/
+
+echo "# config for high-resolution MFCC features, intended for neural network training.
+# Note: we keep all cepstra, so it has the same info as filterbank features,
+# but MFCC is more easily compressible (because less correlated) which is why
+# we prefer this method.
+--use-energy=false   # use average of log energy, not energy.
+--sample-frequency=16000 
+--num-mel-bins=40
+--num-ceps=40
+--low-freq=40
+--high-freq=-400" > ../SAD_model/mfcc.conf
+
+echo "" > ../SAD_model/wav.scp
+
+# Download and extract SAD system from Chime6 challenge
+wget https://kaldi-asr.org/models/12/0012_sad_v1.tar.gz -P ./
+tar xvzf ./0012_sad_v1.tar.gz
+rm ./0012_sad_v1.tar.gz
+
+cp ./0012_sad_v1/exp/segmentation_1a/tdnn_stats_sad_1a/final.raw ../SAD_model/
+cp ./0012_sad_v1/exp/segmentation_1a/tdnn_stats_sad_1a/post_output.vec ../SAD_model/
+
+# Clean unnecessary files
+rm -r ./0012_sad_v1
+
+cd $INITIAL_WORKING_DIRECTORY


### PR DESCRIPTION
### Changes
- Added _**/server/scripts/setup_SAD.sh**_ script which configures the SAD model files
- Updated **_/server/kaldigrpc/config.py_** to include SAD model configuration classes
- Added  **_/server/kaldigrpc/segment.py_** to implement segmentation

### Notes
- Segmentation doesn't support online processing currently. It is possible that this feature will be used at the end of the pipeline on the whole wav.

### Test Usage
- Setup SAD model files
`cd server/scripts`
`./setup_SAD.sh`
- Build server (Optional example with Chime6 ASR model )
(`./setup_chime6.sh`)
`make build-server kaldi_model=/home/george/kaldi-grpc-server/server/chime6_model/ image_tag=kaldigrpc:chime6-latest`
- Run server by mounting your local directory which contains the .wav to be segmented
`docker run -p 1234:1234 -ti -v <local dir>:/tmp  kaldigrpc:chime6-latest --port=1234 --max-workers=3`
- In another terminal enter container's bash
`docker ps`
`docker exec -it <container-id> bash`
- Run segmentation process 
`cd kaldigrpc`
`python segment.py --model-dir=../SAD_model/ --wav=/tmp/<your wav file>`

### TODO
- Add client-side SAD support