### PR TITLE
Added diarization component

### DIFF
--- a/server/kaldigrpc/config.py
+++ b/server/kaldigrpc/config.py
@@ -1,13 +1,13 @@
-import argparse
 import os
 from dataclasses import dataclass
 from typing import Optional
 
 from kaldi.decoder import LatticeFasterDecoderOptions
-from kaldi.nnet3 import NnetSimpleLoopedComputationOptions
+from kaldi.nnet3 import NnetSimpleLoopedComputationOptions, NnetSimpleComputationOptions
 from kaldi.online2 import (OnlineEndpointConfig,
                            OnlineNnetFeaturePipelineConfig,
                            OnlineNnetFeaturePipelineInfo)
+from kaldi.segmentation import NnetSAD, SegmentationProcessor
 from kaldi.util.options import ParseOptions
 
 
@@ -172,6 +172,177 @@ class AsrConfig:
 
         return cfg, args
 
+@dataclass
+class SadModelConfig:
+    finalraw: str = "/kaldigrpc/SAD_model/src"
+    postoutput: str = "/kaldigrpc/SAD_model/src"
+    wavscp: str = "/kaldigrpc/SAD_model/data"
+
+    @classmethod
+    def register(cls, po: ParseOptions):
+        po.register_str("model_dir", "/kaldigrpc/SAD_model", "Path to SAD model")
+
+    @classmethod
+    def from_opts(cls, po: ParseOptions):
+        opts = po._get_options()
+        model_dir = opts.str_map["model_dir"]
+
+        return cls(
+            os.path.join(model_dir, "src/final.raw"),
+            os.path.join(model_dir, "src/post_output.vec"),
+            os.path.join(model_dir, "data/wav.scp")
+        )
+
+@dataclass
+class SadConfig:
+    transform: NnetSAD
+    graph: NnetSAD
+    sad: NnetSAD
+    seg: SegmentationProcessor
+    decodable: NnetSimpleComputationOptions
+    model: SadModelConfig
+    feats_rspec: str
+
+    @classmethod
+    def parse_options(cls, po: Optional[ParseOptions]):
+        SadModelConfig.register(po)
+        model_cfg = SadModelConfig.from_opts(po)
+
+        model = NnetSAD.read_model(model_cfg.finalraw)
+        post = NnetSAD.read_average_posteriors(model_cfg.postoutput)
+        transform = NnetSAD.make_sad_transform(post)
+        graph = NnetSAD.make_sad_graph()
+        decodable_opts = NnetSimpleComputationOptions()
+        decodable_opts.extra_left_context = 79
+        decodable_opts.extra_right_context = 21
+        decodable_opts.extra_left_context_initial = -1
+        decodable_opts.extra_right_context_final = -1
+        decodable_opts.frames_per_chunk = 150
+        decodable_opts.acoustic_scale = 1 # original value from kaldi was 0.3
+
+        sad = NnetSAD(model, transform, graph, decodable_opts=decodable_opts)
+        seg = SegmentationProcessor(target_labels=[2])
+
+        feats_rspec = "ark:compute-mfcc-feats --config=/kaldigrpc/model/conf/mfcc.conf scp:{} ark:- |".format(model_cfg.wavscp)
+        decodable_opts.register(po)
+        args = po.parse_args()
+        
+        po.print_config()
+
+        cfg = cls(
+            transform,
+            graph,
+            sad,
+            seg,
+            decodable_opts,
+            model_cfg,
+            feats_rspec
+        )
+
+        return cfg, args
+
+@dataclass
+class DiarizerModelConfig:
+    finalraw: str = "/kaldigrpc/diarizer_model/src/final.raw"
+    plda: str = "/kaldigrpc/diarizer_model/src/plda"
+    max_chunk_size: str = "/kaldigrpc/diarizer_model/src/max_chunk_size"
+    min_chunk_size: str = "/kaldigrpc/diarizer_model/src/min_chunk_size"
+    extractconfig: str = "/kaldigrpc/diarizer_model/src/extract.config"
+    segments: str = "/kaldigrpc/diarizer_model/data/segments"
+    featsscp: str = "/kaldigrpc/diarizer_model/data/feats.scp"
+
+    @classmethod
+    def register(cls, po: ParseOptions):
+        po.register_str("model_dir", "/kaldigrpc/diarizer_model", "Path to Diarizer model")
+
+    @classmethod
+    def from_opts(cls, po: ParseOptions):
+        opts = po._get_options()
+        model_dir = opts.str_map["model_dir"]
+
+        return cls(
+            os.path.join(model_dir, "src/final.raw"),
+            os.path.join(model_dir, "src/plda"),
+            os.path.join(model_dir, "src/max_chunk_size"),
+            os.path.join(model_dir, "src/min_chunk_size"),
+            os.path.join(model_dir, "src/extract.config"),
+            os.path.join(model_dir, "data/segments"),
+            os.path.join(model_dir, "data/feats.scp")
+        )
+
+@dataclass
+class DiarizerConfig:
+    model_cfg: DiarizerModelConfig
+    feats_rspec: str
+    hard_min: bool
+    min_segment: float
+    window: float
+    period: float
+    min_chunk_size: int
+    nnet: str
+    pca_dim: any
+
+    @classmethod
+    def parse_options(cls, po: Optional[ParseOptions]):
+
+        #TODO Whole config needs cleaning and structuring
+
+        DiarizerModelConfig.register(po)
+        model_cfg = DiarizerModelConfig.from_opts(po)
+
+        chunk_size=-1 # The chunk size over which the embedding is extracted.
+              # If left unspecified, it uses the max_chunk_size in the nnet
+              # directory.
+        window=1.5
+        period=0.75
+        pca_dim=None
+        min_segment=0.5
+        hard_min=False
+        apply_cmn=True # If true, apply sliding window cepstral mean normalization
+        max_chunk_size = 0
+        min_chunk_size = 0
+        nnet = ""
+
+        #TODO Check if input files exist
+        
+        with open(model_cfg.max_chunk_size) as f:
+            max_chunk_size = int(f.readlines()[0].strip())
+        with open(model_cfg.min_chunk_size) as f:
+            min_chunk_size = int(f.readlines()[0].strip())
+
+        #TODO this is unnecessary probably
+        if os.path.exists(model_cfg.extractconfig):
+            nnet= "nnet3-copy --nnet-config={} {} - |".format(model_cfg.extractconfig, model_cfg.finalraw)
+        else:
+            nnet = model_cfg.finalraw
+
+        if chunk_size <= 0:
+            chunk_size = max_chunk_size
+        if max_chunk_size < chunk_size:
+            print("Specified chunk size of {} is larger than the maximum chunk size, {}".format(chunk_size, max_chunk_size))
+        
+        #TODO this is unnecessary probably
+        if apply_cmn:
+            feats_rspec = "ark,s,cs:apply-cmvn-sliding --norm-vars=false --center=true --cmn-window=300 scp:{} ark:- |".format(model_cfg.featsscp)
+        else:
+            feats_rspec="scp:{}".format(model_cfg.featsscp)
+
+        args = po.parse_args()
+        po.print_config()
+
+        cfg = cls(
+            model_cfg,
+            feats_rspec,
+            hard_min,
+            min_segment,
+            window,
+            period,
+            min_chunk_size,
+            nnet,
+            pca_dim
+        )
+
+        return cfg, args
 
 if __name__ == "__main__":
     cfg = AsrConfig.parse_options()

--- a/server/kaldigrpc/diarize.py
+++ b/server/kaldigrpc/diarize.py
@@ -1,0 +1,91 @@
+from __future__ import print_function
+from kaldi.util.table import MatrixWriter, SequentialMatrixReader
+from kaldi.util.options import ParseOptions
+from kaldigrpc.config import DiarizerConfig, SadConfig
+from kaldigrpc.segment import KaldiSegmentor
+import sys
+import os
+import subprocess
+from os.path import dirname, join
+sys.path.insert(0, join(dirname(__file__), '..'))
+from scripts import xvectors, plda, cluster, split_wav
+
+
+class KaldiDiarizer:
+
+    def __init__(self, cfg: DiarizerConfig):
+        self.config = cfg
+
+    @classmethod
+    def register(cls, po: ParseOptions):
+        po.register_str("wav", "", "Path to wav file for decoding")
+        po.register_bool("streaming", False, "Use streaming online segmentor")
+
+    def diarize(self, wav_path):
+        # Create segments file with the help of SAD component
+        po = ParseOptions(
+            """SAD using Kaldi.
+            Usage:
+                python segment.py --model-dir=/model/ --wav=/path/to/test.wav
+            """
+        )
+        KaldiSegmentor.register(po)
+        config, args = SadConfig.parse_options(po)
+        sad = KaldiSegmentor(config, args)
+        sad.segment()
+        os.system("cp /kaldigrpc/SAD_model/data/segments /kaldigrpc/diarizer_model/data/")
+
+        # Create wav.scp
+        with open("/kaldigrpc/diarizer_model/data/wav.scp", "w") as f:
+            f.write("utt1 " + wav_path)
+
+        ### Segments extraction from wav
+        split_wav.extract_segments("scp:/kaldigrpc/diarizer_model/data/wav.scp", "/kaldigrpc/diarizer_model/data/segments",
+                                  "ark,scp:/kaldigrpc/diarizer_model/data/wav2.ark,/kaldigrpc/diarizer_model/data/wav2.scp", self.config.min_segment)
+        
+        ### Create additional necessary files
+        # create utt2spk
+        os.system(
+            "awk -v var="+str(self.config.min_segment)+" '{if ($4 - $3 >= var) {print $1, $2}}' /kaldigrpc/diarizer_model/data/segments > /kaldigrpc/diarizer_model/data/utt2spk")
+        # create spk2utt
+        with open("/kaldigrpc/diarizer_model/data/spk2utt", 'a+') as file:
+            subprocess.Popen(["../scripts/utt2spk_to_spk2utt.pl",
+                             "/kaldigrpc/diarizer_model/data/utt2spk"], stdout=file)
+        # remove minimum segments from segments file
+        os.system(
+            "awk -v var="+str(self.config.min_segment)+" '{if ($4 - $3 >= var) {print $1, $2, $3, $4}}' /kaldigrpc/diarizer_model/data/segments > /kaldigrpc/diarizer_model/data/filtered_segments")
+
+        ### Feature Computation
+        print("\nComputing mfcc features...")
+        feats_rspecifier = (
+            "ark:compute-mfcc-feats --config=/kaldigrpc/model/conf/mfcc.conf scp:/kaldigrpc/diarizer_model/data/wav2.scp ark:- |"
+        )
+
+        with MatrixWriter("ark,scp:../diarizer_model/data/feats.ark,../diarizer_model/data/feats.scp") as writer:
+            for key, feats in SequentialMatrixReader(feats_rspecifier):
+                writer[key] = feats
+        print("Operation complete!")
+
+        ### X-vector Extraction
+        xvectors.extract_vectors(self.config, apply_cmn=False, window=1.5)
+        ### PLDA Scoring
+        plda.score_plda(self.config, target_energy=0.5) 
+        ### Clustering
+        cluster.apply_clustering(self.config, rttm_channel=1)
+
+def transcribe_wav():
+    po = ParseOptions(
+        """Diarization using Kaldi.
+        Usage:
+            python diarize.py --wav=/path/to/test.wav
+        """
+    )
+
+    KaldiDiarizer.register(po)
+    config, args = DiarizerConfig.parse_options(po)
+    diarizer = KaldiDiarizer(config)
+    diarizer.diarize(args.wav)
+
+
+if __name__ == "__main__":
+    transcribe_wav()

--- a/server/kaldigrpc/segment.py
+++ b/server/kaldigrpc/segment.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
+from kaldi.util.options import ParseOptions
+from kaldi.util.table import SequentialMatrixReader
+from kaldigrpc.config import SadConfig
+
+class KaldiSegmentor:
+    def __init__(self, cfg: SadConfig, args):
+        self.config = cfg
+        self.wav = args.wav
+
+    @classmethod
+    def register(cls, po: ParseOptions):
+        po.register_str("wav", "", "Path to wav file for decoding")
+        po.register_bool("streaming", False, "Use streaming online segmentor")
+
+    def segment(self):
+
+        with open(self.config.model.wavscp, "w+") as f:
+            f.write("utt1 " + self.wav)
+
+        with SequentialMatrixReader(self.config.feats_rspec) as f, open(
+            "/kaldigrpc/SAD_model/data/segments", "w+"
+        ) as s:
+            for key, feats in f:
+                out = self.config.sad.segment(feats)
+                segments, stats = self.config.seg.process(out["alignment"])
+                self.config.seg.write(key, segments, s)
+                # print("segments:", segments, flush=True)
+                # print("stats:", stats, flush=True)
+        print("global stats:", self.config.seg.stats, flush=True)
+
+
+def transcribe_wav():
+    po = ParseOptions(
+        """SAD using Kaldi.
+        Usage:
+            python segment.py --model-dir=/model/ --wav=/path/to/test.wav
+        """
+    )
+
+    KaldiSegmentor.register(po)
+    config, args = SadConfig.parse_options(po)
+    sad = KaldiSegmentor(config, args)
+    sad.segment()
+
+
+if __name__ == "__main__":
+    transcribe_wav()

--- a/server/scripts/cluster.py
+++ b/server/scripts/cluster.py
@@ -1,0 +1,87 @@
+import sys
+import subprocess
+import os
+
+from kaldi.util.table import SequentialMatrixReader, IntWriter, RandomAccessIntReader
+from kaldi.ivector import AgglomerativeClusterer
+from .plda import read_reco2utt
+from .make_rttm import create_rttm
+
+
+def apply_clustering(config, rttm_channel=1):
+    print("Performing clustering using PLDA scores...")
+
+    os.system(
+        "awk '{print $1, '4'}' /kaldigrpc/diarizer_model/data/wav.scp > /kaldigrpc/diarizer_model/data/reco2num_spk")
+
+    print("Starting agglomerative clustering...")
+    agglomerative_cluster("scp:/kaldigrpc/diarizer_model/data/scores.scp",
+                          "/kaldigrpc/diarizer_model/data/spk2utt",
+                          "ark,t:/kaldigrpc/diarizer_model/data/labels",
+                          "ark,t:/kaldigrpc/diarizer_model/data/reco2num_spk", threshold = 0.4)
+
+    print("Computing RTTM...")
+    create_rttm("/kaldigrpc/diarizer_model/data/filtered_segments", "/kaldigrpc/diarizer_model/data/labels", "/kaldigrpc/diarizer_model/data/rttm", rttm_channel)
+
+    print("Clustering complete!")
+
+def agglomerative_cluster(scores_rspecifier, reco2utt_rspecifier, label_wspecifier, reco2num_spk_rspecifier=None, threshold=0.0, max_spk_fraction=1.0, read_costs=False, first_pass_max_utterances=32767):
+    try:
+        usage = '''
+        "Cluster utterances by similarity score, used in diarization.\n"
+        "Takes a table of score matrices indexed by recording, with the\n"
+        "rows/columns corresponding to the utterances of that recording in\n"
+        "sorted order and a reco2utt file that contains the mapping from\n"
+        "recordings to utterances, and outputs a list of labels in the form\n"
+        "<utt> <label>.  Clustering is done using agglomerative hierarchical\n"
+        "clustering with a score threshold as stop criterion.  By default, the\n"
+        "program reads in similarity scores, but with --read-costs=true\n"
+        "the scores are interpreted as costs (i.e. a smaller value indicates\n"
+        "utterance similarity).\n"
+        "Usage: agglomerative-cluster [options] <scores-rspecifier> "
+        "<reco2utt-rspecifier> <labels-wspecifier>\n"
+        "e.g.: \n"
+        " agglomerative-cluster ark:scores.ark ark:reco2utt \n"
+        "   ark,t:labels.txt\n"
+            '''
+
+        scores_reader = SequentialMatrixReader(scores_rspecifier)
+        reco2utt_reader = read_reco2utt(reco2utt_rspecifier)
+        reco2num_spk_reader = RandomAccessIntReader(reco2num_spk_rspecifier)
+        label_writer = IntWriter(label_wspecifier)
+
+        if read_costs == 0:
+            threshold = -threshold
+
+        for reco, costs in scores_reader:
+            # By default, the scores give the similarity between pairs of
+            # utterances.  We need to multiply the scores by -1 to reinterpet
+            # them as costs (unless --read-costs=true) as the agglomerative
+            # clustering code requires.
+
+            if read_costs == 0:
+                costs.scale_(-1)
+
+            uttlist = reco2utt_reader[reco]
+            spk_ids = []
+
+            if reco2num_spk_rspecifier is not None:
+                num_speakers = reco2num_spk_reader.value(reco)
+
+                if 1.0 / num_speakers <= max_spk_fraction and max_spk_fraction <= 1.0:
+                    spk_ids = AgglomerativeClusterer(costs, sys.float_info.max,
+                                                     num_speakers, first_pass_max_utterances, max_spk_fraction).cluster()
+                else:
+                    spk_ids = AgglomerativeClusterer(costs, sys.float_info.max,
+                                                     num_speakers, first_pass_max_utterances, 1.0).cluster()
+            else:
+                spk_ids = AgglomerativeClusterer(
+                    costs, threshold, 1, first_pass_max_utterances, 1.0).cluster()
+
+            for i in range(len(spk_ids)):
+                label_writer.write(uttlist[i], spk_ids[i])
+
+        return 0
+    except Exception as e:
+        print(str(e))
+        return -1

--- a/server/scripts/make_rttm.py
+++ b/server/scripts/make_rttm.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+
+# Copyright  2016  David Snyder
+#            2017  Matthew Maciejewski
+# Apache 2.0.
+
+"""This script converts a segments and labels file to a NIST RTTM
+file. It creates flat segmentation (i.e. no overlapping regions)
+from overlapping segments, e.g. the output of a sliding-window
+diarization system. The speaker boundary between two overlapping
+segments by different speakers is placed at the midpoint between
+the end of the first segment and the start of the second segment.
+The segments file format is:
+<segment-id> <recording-id> <start-time> <end-time>
+The labels file format is:
+<segment-id> <speaker-id>
+The output RTTM format is:
+<type> <file> <chnl> <tbeg> \
+        <tdur> <ortho> <stype> <name> <conf> <slat>
+where:
+<type> = "SPEAKER"
+<file> = <recording-id>
+<chnl> = "0"
+<tbeg> = start time of segment
+<tdur> = duration of segment
+<ortho> = "<NA>"
+<stype> = "<NA>"
+<name> = <speaker-id>
+<conf> = "<NA>"
+<slat> = "<NA>"
+"""
+import codecs
+
+def create_rttm(segments, labels, rttm_file, rttm_channel=0):
+
+  # File containing speaker labels per segment
+  seg2label = {}
+  try:
+    with codecs.open(labels, 'r', 'utf-8') as labels_file:
+      for line in labels_file:
+        seg, label = line.strip().split()
+        seg2label[seg] = label
+  except Exception as e:
+    print(str(e))
+
+  # Segments file
+  reco2segs = {}
+  with codecs.open(segments, 'r', 'utf-8') as segments_file:
+    for line in segments_file:
+      seg, reco, start, end = line.strip().split()
+      try:
+        if reco in reco2segs:
+          reco2segs[reco] = reco2segs[reco] + " " + start + "," + end + "," + seg2label[seg]
+        else:
+          reco2segs[reco] = reco + " " + start + "," + end + "," + seg2label[seg]
+      except KeyError:
+        raise RuntimeError("Missing label for segment {0}".format(seg))
+
+
+  # Cut up overlapping segments so they are contiguous
+  contiguous_segs = []
+  for reco in sorted(reco2segs):
+    segs = reco2segs[reco].strip().split()
+    new_segs = ""
+    for i in range(1, len(segs)-1):
+      start, end, label = segs[i].split(',')
+      next_start, next_end, next_label = segs[i+1].split(',')
+      if float(end) > float(next_start):
+        done = False
+        avg = str((float(next_start) + float(end)) / 2.0)
+        segs[i+1] = ','.join([avg, next_end, next_label])
+        new_segs += " " + start + "," + avg + "," + label
+      else:
+        new_segs += " " + start + "," + end + "," + label
+    start, end, label = segs[-1].split(',')
+    new_segs += " " + start + "," + end + "," + label
+    contiguous_segs.append(reco + new_segs)
+
+  # Merge contiguous segments of the same label
+  merged_segs = []
+  for reco_line in contiguous_segs:
+    segs = reco_line.strip().split()
+    reco = segs[0]
+    new_segs = ""
+    for i in range(1, len(segs)-1):
+      start, end, label = segs[i].split(',')
+      next_start, next_end, next_label = segs[i+1].split(',')
+      if float(end) == float(next_start) and label == next_label:
+        segs[i+1] = ','.join([start, next_end, next_label])
+      else:
+        new_segs += " " + start + "," + end + "," + label
+    start, end, label = segs[-1].split(',')
+    new_segs += " " + start + "," + end + "," + label
+    merged_segs.append(reco + new_segs)
+
+  with codecs.open(rttm_file, 'w', 'utf-8') as rttm_writer:
+    for reco_line in merged_segs:
+      segs = reco_line.strip().split()
+      reco = segs[0]
+      for i in range(1, len(segs)):
+        start, end, label = segs[i].strip().split(',')
+        print("SPEAKER {0} {1} {2:7.3f} {3:7.3f} <NA> <NA> {4} <NA> <NA>".format(
+          reco, rttm_channel, float(start), float(end)-float(start), label), file=rttm_writer)

--- a/server/scripts/plda.py
+++ b/server/scripts/plda.py
@@ -1,0 +1,360 @@
+from kaldi.ivector import Plda, PldaConfig
+from kaldi import util
+from kaldi.util.table import SequentialVectorReader, RandomAccessVectorReader, MatrixWriter, VectorWriter
+from kaldi.matrix import Vector, Matrix, DoubleMatrix, DoubleVector
+from kaldi.matrix.packed import SpMatrix
+from kaldi.base.math import approx_equal
+from kaldi.matrix.common import MatrixTransposeType, MatrixResizeType
+import numpy
+import math
+
+
+def score_plda(config, target_energy=0.1):
+    print("\nInitializing PLDA scoring...")
+
+    ivector_subtract_global_mean("ark:/kaldigrpc/diarizer_model/data/xvectors.ark",
+                                 "/kaldigrpc/diarizer_model/data/mean.vec", "ark:/kaldigrpc/diarizer_model/data/subtracted_mean_xvectors.ark")
+    transform_vec("/kaldigrpc/diarizer_model/data/transform.mat", "ark:/kaldigrpc/diarizer_model/data/subtracted_mean_xvectors.ark",
+                  "ark:/kaldigrpc/diarizer_model/data/transformed_subtracted_mean_xvectors.ark")
+    ivector_normalize_length("ark:/kaldigrpc/diarizer_model/data/transformed_subtracted_mean_xvectors.ark",
+                             "ark:/kaldigrpc/diarizer_model/data/plda_xvectors.ark")
+
+    print("\nScoring xvectors...")
+    ivector_plda_scoring_dense(config.model_cfg.plda, "/kaldigrpc/diarizer_model/data/spk2utt", "ark:/kaldigrpc/diarizer_model/data/plda_xvectors.ark",
+                               "ark,scp:/kaldigrpc/diarizer_model/data/scores.ark,/kaldigrpc/diarizer_model/data/scores.scp", target_energy)
+
+    print("\nPLDA scoring complete!")
+
+def ivector_subtract_global_mean(ivector_rspecifier, mean_rxfilename=None, ivector_wspecifier=None):
+    usage = '''
+    "Copies a table of iVectors but subtracts the global mean as\n"
+        "it does so.  The mean may be specified as the first argument; if not,\n"
+        "the sum of the input iVectors is used.\n"
+        "\n"
+        "Usage: ivector-subtract-global-mean <ivector-rspecifier> <ivector-wspecifier>\n"
+        "or: ivector-subtract-global-mean <mean-rxfliename> <ivector-rspecifier> <ivector-wspecifier>\n"
+        "e.g.: ivector-subtract-global-mean scp:ivectors.scp ark:-\n"
+        "or: ivector-subtract-global-mean mean.vec scp:ivectors.scp ark:-\n"
+        "See also: ivector-mean\n";
+    '''
+    try:
+        subtract_mean = True
+        if ivector_rspecifier is None:
+            print(usage)
+            exit(1)
+
+        num_done = 0
+
+        if mean_rxfilename is None:
+            sum = Vector()
+            ivectors = Vector()
+
+            ivector_reader = SequentialVectorReader(ivector_rspecifier)
+            ivector_writer = VectorWriter(ivector_wspecifier)
+
+            for key, ivector in ivector_reader:
+                if (sum.dim == 0):
+                    sum.resize_(ivector.dim)
+                sum.add_vec_(1.0, ivector)
+                num_done += 1
+                ivectors.append([key, Vector(ivector)])
+
+            print("LOG: Read " + str(num_done) + " iVectors.")
+
+            if num_done != 0:
+                print("LOG: Norm of iVector mean was " +
+                      str(sum.Norm(2.0) / num_done))
+                for i in range(ivectors.size()):
+                    key = ivectors[i][0]
+                    
+                    ivector = ivectors[i][1]
+                    if subtract_mean:
+                        ivector.add_vec_(-1.0 / num_done, sum)
+                    ivector_writer.write(key, ivector)
+                    ivectors[i][1] = None
+        else:
+            mean = Vector()
+            istream = util.io.Input(mean_rxfilename)
+            mean.read_(istream.stream(), binary=False)
+
+            ivector_reader = SequentialVectorReader(ivector_rspecifier)
+            ivector_writer = VectorWriter(ivector_wspecifier)
+            for key, ivector in ivector_reader:
+                ivector.add_vec_(-1.0, mean)
+                ivector_writer.write(key, ivector)
+                num_done += 1
+
+        print("LOG: Wrote " + str(num_done) + " mean-subtracted iVectors")
+        return 0 if num_done != 0 else 1
+    except Exception as e:
+        print(str(e))
+        return -1
+
+
+def transform_vec(transform_rxfilename, vec_rspecifier, vec_wspecifier):
+    '''
+        "This program applies a linear or affine transform to individual vectors, e.g.\n"
+        "iVectors.  It is transform-feats, except it works on vectors rather than matrices,\n"
+        "and expects a single transform matrix rather than possibly a table of matrices\n"
+        "\n"
+        "Usage: transform-vec [options] <transform-rxfilename> <feats-rspecifier> <feats-wspecifier>\n"
+        "See also: transform-feats, est-pca\n"
+    '''
+    try:
+        vec_reader = SequentialVectorReader(vec_rspecifier)
+        vec_writer = VectorWriter(vec_wspecifier)
+
+        transform = Matrix()
+        istream = util.io.Input(transform_rxfilename)
+        transform.read_(istream.stream(), binary=False)
+
+        num_done = 0
+        for key, vec in vec_reader:
+            transform_rows = transform.num_rows
+            transform_cols = transform.num_cols
+            vec_dim = vec.dim
+
+            vec_out = Vector(transform_rows)
+
+            if transform_cols == vec_dim:
+                vec_out.add_mat_vec_(
+                    1.0, transform, MatrixTransposeType.NO_TRANS, vec, 0.0)
+            else:
+                if transform_cols != vec_dim + 1:
+                    print("Error: Dimension mismatch: input vector has dimension " +
+                          str(vec.dim) + " and transform has " + str(transform_cols) + " columns.")
+                vec_out.copy_col_from_mat_(transform, vec_dim)
+                vec_out.add_mat_vec_(1.0, transform.range(
+                    0, transform.num_rows, 0, vec_dim), MatrixTransposeType.NO_TRANS, vec, 1.0)
+
+            vec_writer.write(key, vec_out)
+            num_done += 1
+
+        print("LOG: Applied transform to " + str(num_done) + " vectors.")
+
+        return 0 if num_done != 0 else 1
+    except Exception as e:
+        print(str(e))
+        return -1
+
+
+def ivector_normalize_length(ivector_rspecifier, ivector_wspecifier):
+    '''
+        "Normalize length of iVectors to equal sqrt(feature-dimension)\n"
+        "\n"
+        "Usage:  ivector-normalize-length [options] <ivector-rspecifier> "
+        "<ivector-wspecifier>\n"
+        "e.g.: \n"
+        " ivector-normalize-length ark:ivectors.ark ark:normalized_ivectors.ark\n"
+    '''
+    try:
+        normalize = True
+        scaleup = True
+        num_done = 0
+        tot_ratio, tot_ratio2 = 0.0, 0.0
+        ivector_reader = SequentialVectorReader(ivector_rspecifier)
+        ivector_writer = VectorWriter(ivector_wspecifier)
+
+        for key, ivector in ivector_reader:
+            norm = ivector.norm(2.0)
+            # how much larger it is than it would be, in expectation, if normally
+            ratio = norm / math.sqrt(ivector.dim)
+
+            if scaleup == 0:
+                ratio = norm
+
+            print("VLOG: Ratio for key " + str(key) + " is " + str(ratio))
+
+            if ratio == 0.0:
+                print("WARNING: Zero iVector")
+            elif normalize:
+                ivector.scale_(1.0 / ratio)
+
+            ivector_writer.write(key, ivector)
+            tot_ratio += ratio
+            tot_ratio2 += ratio * ratio
+            num_done += 1
+
+        print("LOG: Processed " + str(num_done) + " iVectors.")
+        if num_done != 0:
+            avg_ratio = tot_ratio / num_done
+            ratio_stddev = math.sqrt(
+                tot_ratio2 / num_done - avg_ratio * avg_ratio)
+            print("LOG: Average ratio of iVector to expected length was " +
+                  str(avg_ratio) + ", standard deviation was " + str(ratio_stddev))
+
+        return 0 if num_done != 0 else 1
+    except Exception as e:
+        print(str(e))
+        return -1
+
+def ivector_plda_scoring_dense(plda_rxfilename, reco2utt_rspecifier, ivector_rspecifier, scores_wspecifier, target_energy=0.5):
+    try:
+        plda_config = PldaConfig()
+        assert target_energy <= 1.0
+
+        plda = Plda()
+        istream = util.io.Input(plda_rxfilename)
+        plda.read(istream.stream(), binary=True)
+
+        reco2utt_reader = read_reco2utt(reco2utt_rspecifier)
+        ivector_reader = RandomAccessVectorReader(ivector_rspecifier)
+        scores_writer = MatrixWriter(scores_wspecifier)
+
+        num_reco_err = 0
+        num_reco_done = 0
+
+        for reco, uttlist in reco2utt_reader.items():
+            this_plda = Plda().from_other(plda)
+            ivectors = []
+
+            for i in range(len(uttlist)):
+                utt = uttlist[i]
+
+                if not ivector_reader.has_key(utt):
+                    print(
+                        "ERROR: No iVector present in input for utterance " + str(utt))
+
+                ivector = ivector_reader.value(utt)
+                ivectors.append(ivector)
+
+            if len(ivectors) == 0:
+                print("WARNING: Not producing output for recording " +
+                      str(reco) + " since no segments had iVectors")
+                num_reco_err += 1
+            else:
+                ivector_mat = Matrix(len(ivectors), ivectors[0].dim)
+                ivector_mat_pca, ivector_mat_plda, pca_transform = Matrix(), Matrix(), Matrix()
+                scores = Matrix(len(ivectors), len(ivectors))
+
+                for i in range(len(ivectors)):
+                    ivector_mat.row(i).copy_(ivectors[i])
+
+                if est_pca_plda(ivector_mat, target_energy, reco, pca_transform):
+                    # Apply the PCA transform to the raw i-vectors.
+                    apply_pca(ivector_mat, pca_transform, ivector_mat_pca)
+
+                    # Apply the PCA transform to the parameters of the PLDA model.
+                    this_plda.apply_transform(DoubleMatrix(pca_transform))
+
+                    # Now transform the i-vectors using the reduced PLDA model.
+                    transform_ivectors(
+                        ivector_mat_pca, plda_config, this_plda, ivector_mat_plda)
+
+                else:
+                    # If EstPca returns false, we won't apply any PCA.
+                    transform_ivectors(
+                        ivector_mat, plda_config, this_plda, ivector_mat_plda)
+
+                for i in range(ivector_mat_plda.num_rows):
+                    for j in range(ivector_mat_plda.num_rows):
+                        scores[i][j] = this_plda.log_likelihood_ratio(
+                            DoubleVector(ivector_mat_plda.row(i)), 1, DoubleVector(ivector_mat_plda.row(j)))
+
+                scores_writer.write(reco, scores)
+                num_reco_done += 1
+
+        print("Processed " + str(num_reco_done) +
+              " recordings, " + str(num_reco_err) + " had errors.")
+        return 0 if num_reco_done != 0 else 1
+
+    except Exception as e:
+        print(str(e))
+        return -1
+
+
+def est_pca_plda(ivector_mat, target_energy, reco, mat):
+    if approx_equal(target_energy, 1.0, 0.001):
+        return False
+
+    num_rows = ivector_mat.num_rows
+    num_cols = ivector_mat.num_cols
+    sum = Vector()
+    sumsq = SpMatrix()
+    sum.resize_(num_cols)
+    sumsq.resize_(num_cols)
+    sum.add_row_sum_mat_(1.0, ivector_mat)
+    sumsq.add_mat2_(1.0, ivector_mat, MatrixTransposeType.TRANS, 1.0)
+    sum.scale_(1.0 / num_rows)
+    sumsq.scale_(1.0 / num_rows)
+    sumsq.add_vec2_(-1.0, sum)    # now sumsq is centered covariance.
+    full_dim = sum.dim
+
+    P = Matrix(full_dim, full_dim)
+    s = Vector(full_dim)
+
+    try:
+        sumsq = Matrix(sumsq)
+        u, s, vh = numpy.linalg.svd(sumsq)
+        s = Vector(s)
+        P = Matrix(u)
+    except:
+        print("WARNING: Unable to compute conversation dependent PCA for recording " + str(reco) + ".")
+
+    # Transpose of P.  This is what appears in the transform.
+    transform = P.transpose_()
+    # We want the PCA transform to retain target_energy amount of the total
+    # energy.
+    total_energy = s.sum()
+    energy = 0.0
+    dim = 1
+    while (energy/total_energy) <= target_energy:
+        energy += s[dim-1]
+        dim += 1
+    transform_float = Matrix(transform)
+
+    mat.resize_(transform.num_cols, transform.num_rows)
+    mat.copy_(transform)
+    mat.resize_(dim, transform_float.num_cols, MatrixResizeType.COPY_DATA)
+
+    return True
+
+
+def transform_ivectors(ivectors_in, plda_config, plda, ivectors_out):
+    '''
+    Transforms i-vectors using the PLDA model.
+    '''
+    dim = plda.dim()
+    ivectors_out.resize_(ivectors_in.num_rows, dim)
+
+    for i in range(ivectors_in.num_rows):
+        transformed_ivector = DoubleVector(dim)
+        plda.transform_ivector(plda_config, DoubleVector(
+            ivectors_in.row(i)), 1, transformed_ivector)
+        ivectors_out.row(i).copy_(transformed_ivector)
+
+    return
+
+
+def apply_pca(ivectors_in, pca_mat, ivectors_out):
+    '''
+    Transform the i-vectors using the recording-dependent PCA matrix.
+    '''
+    transform_cols = pca_mat.num_cols
+    transform_rows = pca_mat.num_rows
+    feat_dim = ivectors_in.num_cols
+    ivectors_out.resize_(ivectors_in.num_rows, transform_rows)
+    assert transform_cols == feat_dim
+    ivectors_out.add_mat_mat_(
+        ivectors_in, pca_mat, MatrixTransposeType.NO_TRANS, MatrixTransposeType.TRANS, 1.0, 0.0)
+
+def read_reco2utt(reco2utt):
+    '''
+    Reads a reco2utt (spk2utt) file and returns a dictionary of it
+    '''
+
+    myDict = {}
+    with open(reco2utt) as f:
+        lines = f.read().splitlines()
+
+    for i in lines:
+        temp = i.split(" ", 1)
+        reco = temp[0]
+        utterances = [s.replace("[", "").replace("]", "").replace("/", "").strip() for s in temp[1].split(" ")]
+
+        if reco not in myDict:
+            myDict[reco] = utterances
+        else:
+            myDict[reco].extend(utterances)
+
+    return myDict

--- a/server/scripts/setup_SAD.sh
+++ b/server/scripts/setup_SAD.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+INITIAL_WORKING_DIRECTORY=$(pwd)
+cd "$(dirname "$0")"
+
+# create SAD model tree structure
+mkdir ../SAD_model/
+mkdir ../SAD_model/src/
+mkdir ../SAD_model/data/
+
+echo "" > ../SAD_model/src/wav.scp
+
+# Download and extract SAD system from Chime6 challenge
+wget https://kaldi-asr.org/models/12/0012_sad_v1.tar.gz -P ./
+tar xvzf ./0012_sad_v1.tar.gz
+rm ./0012_sad_v1.tar.gz
+
+cp ./0012_sad_v1/exp/segmentation_1a/tdnn_stats_sad_1a/final.raw ../SAD_model/src/
+cp ./0012_sad_v1/exp/segmentation_1a/tdnn_stats_sad_1a/post_output.vec ../SAD_model/src/
+
+# Clean unnecessary files
+rm -r ./0012_sad_v1
+
+cd $INITIAL_WORKING_DIRECTORY

--- a/server/scripts/setup_diarizer.sh
+++ b/server/scripts/setup_diarizer.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+INITIAL_WORKING_DIRECTORY=$(pwd)
+cd "$(dirname "$0")"
+
+# create SAD model tree structure
+mkdir ../diarizer_model/
+mkdir ../diarizer_model/src
+mkdir ../diarizer_model/data
+
+# Download and extract SAD system from Chime6 challenge
+wget https://kaldi-asr.org/models/12/0012_diarization_v1.tar.gz -P ./
+tar xvzf ./0012_diarization_v1.tar.gz
+rm ./0012_diarization_v1.tar.gz
+
+cp ./0012_diarization_v1/exp/xvector_nnet_1a/final.raw ../diarizer_model/src/
+cp ./0012_diarization_v1/exp/xvector_nnet_1a/plda ../diarizer_model/src/
+cp ./0012_diarization_v1/exp/xvector_nnet_1a/max_chunk_size ../diarizer_model/src/
+cp ./0012_diarization_v1/exp/xvector_nnet_1a/min_chunk_size ../diarizer_model/src/
+cp ./0012_diarization_v1/exp/xvector_nnet_1a/extract.config ../diarizer_model/src/
+cp ./0012_diarization_v1/exp/xvector_nnet_1a/mean.vec ../diarizer_model/src/
+echo "--vad-energy-threshold=5.5
+--vad-energy-mean-scale=0.5" > ../diarizer_model/src/vad.conf
+
+# Clean unnecessary files
+rm -r ./0012_diarization_v1
+
+cd $INITIAL_WORKING_DIRECTORY

--- a/server/scripts/split_wav.py
+++ b/server/scripts/split_wav.py
@@ -1,0 +1,156 @@
+import numpy as np
+import re
+
+from kaldi import util
+from kaldi.matrix import SubMatrix
+from kaldi.util.table import RandomAccessWaveReader, WaveWriter
+from kaldi.feat.wave import WaveData
+
+
+def extract_segments(wav_rspecifier, segments_rxfilename, wav_wspecifier, min_segment_length=0.1, max_overshoot=0.5):
+    print("Extracting segments from wav file...")
+    try:
+        usage = ''' 
+            "Extract segments from a large audio file in WAV format.\n"
+            "Usage:  extract-segments [options] <wav-rspecifier> <segments-file> <wav-wspecifier>\n"
+            "e.g. extract-segments scp:wav.scp segments ark:- | <some-other-program>\n"
+            " segments-file format: each line is either\n"
+            "<segment-id> <recording-id> <start-time> <end-time>\n"
+            "e.g. call-861225-A-0050-0065 call-861225-A 5.0 6.5\n"
+            "or (less frequently, and not supported in scripts):\n"
+            "<segment-id> <wav-file-name> <start-time> <end-time> <channel>\n"
+            "where <channel> will normally be 0 (left) or 1 (right)\n"
+            "e.g. call-861225-A-0050-0065 call-861225 5.0 6.5 1\n"
+            "And <end-time> of -1 means the segment runs till the end of the WAV file\n"
+            "See also: extract-feature-segments, wav-copy, wav-to-duration\n"'''
+
+        reader = RandomAccessWaveReader(wav_rspecifier)
+        writer = WaveWriter(wav_wspecifier)
+        istream = util.io.Input(segments_rxfilename, binary=False)
+
+        num_lines = 0
+        num_success = 0
+
+        while 1:
+            line = istream.readline()
+            if not line:
+                break
+
+            num_lines += 1
+            split_line = re.split(" |\t|\r", line.strip())
+
+            if len(split_line) != 4 and len(split_line) != 5:
+                print("Warning: Invalid line in segments file: " + str(line))
+                continue
+
+            segment = split_line[0]
+            recording = split_line[1]
+            start_str = split_line[2]
+            end_str = split_line[3]
+
+            # Parse the start and end times as float values. Segment is ignored if
+            # any of end times is malformed.
+            start, end = None, None
+
+            start = float(start_str)
+            if start is None:
+                print(
+                    "Warning: Invalid line in segments file [bad start]: " + str(line))
+                continue
+
+            end = float(end_str)
+            if end is None:
+                print(
+                    "Warning: Invalid line in segments file [bad end]: " + str(line))
+                continue
+
+            # Start time must be non-negative and not greater than the end time,
+            # except if the end time is -1.
+            if (start < 0 or (end != -1.0 and end <= 0) or ((start >= end) and (end > 0))):
+                print(
+                    "Warning: Invalid line in segments file [empty or invalid segment]: " + str(line))
+                continue
+
+            channel = -1  # -1 means channel is unspecified.
+            # If the line has 5 elements, then the 5th element is the channel number.
+            if len(split_line) == 5:
+                channel = int(split_line[4])
+                if not channel or channel < 0:
+                    print(
+                        "Warning: Invalid line in segments file [bad channel]: " + str(line))
+                    continue
+
+            # Check whether the recording ID is in wav.scp; if not, skip the segment.
+            if not reader.has_key(recording):
+                print("Warning: Could not find recording " +
+                      str(recording) + ", skipping segment " + str(segment))
+                continue
+
+            wave = reader.value(recording)
+            wave_data = wave.data()
+            samp_freq = wave.samp_freq  # Sampling fequency.
+            num_samp = wave_data.num_cols,  # Number of samples in recording.
+            num_chan = wave_data.num_rows  # Number of channels in recording.
+            file_length = num_samp[0] / samp_freq  # In seconds.
+
+            # Start must be within the wave data, otherwise skip the segment.
+            if start < 0 or start > file_length:
+                print("Warning: Segment start is out of file data range [0, " + str(
+                    file_length) + "s]; skipping segment '" + str(line) + "'")
+                continue
+
+            # End must be less than the file length adjusted for possible overshoot;
+            # otherwise skip the segment. end == -1 passes the check.
+            if end > file_length + max_overshoot:
+                print("Warning: Segment end is too far out of file data range [0," + str(
+                    file_length) + "s]; skipping segment '" + str(line) + "'")
+                continue
+
+            # Otherwise ensure the end is not beyond the end of data, and default
+            # end == -1 to the end of file data.
+            if end < 0 or end > file_length:
+                end = file_length
+
+            # Skip if segment size is less than the minimum allowed.
+            if end - start < min_segment_length:
+                print("Warning: Segment " + str(segment) +
+                      " too short, skipping it.")
+                continue
+
+
+            # Check that the channel is specified in the segments file for a multi-
+            # channel file, and that the channel actually exists in the wave data.
+            if channel == -1:
+                if num_chan == 1:
+                    channel = 0
+                else:
+                    print("Error: Your data has multiple channels. You must specify the channel in the segments file. "
+                          "Skipping segment " + str(segment))
+            else:
+                if channel >= num_chan:
+                    print("Warning: Invalid channel " + str(channel) + " >= " +
+                          str(num_chan) + ". Skipping segment " + str(segment))
+                    continue
+
+            # Convert endpoints of the segment to sample numbers. Note that the
+            # conversion requires a proper rounding.
+            start_samp = int(start * samp_freq + 0.5)
+            end_samp = int(end * samp_freq + 0.5)
+
+            if end_samp > num_samp[0]:
+                end_samp = num_samp[0]
+
+            # Get the range of data from the orignial wave_data matrix.
+            segment_matrix = SubMatrix(
+                wave_data, channel, 1, start_samp, end_samp - start_samp)
+            segment_wave = WaveData.from_data(samp_freq, segment_matrix)
+            # Write the range in wave format.
+            writer.write(segment, segment_wave)
+            num_success += 1
+
+        print("Log: Successfully processed " + str(num_success) +
+              " lines out of " + str(num_lines) + " in the segments file. ")
+        return 0
+    except Exception as e:
+        print(str(e))
+        return -1

--- a/server/scripts/utt2spk_to_spk2utt.pl
+++ b/server/scripts/utt2spk_to_spk2utt.pl
@@ -1,0 +1,38 @@
+#!/usr/bin/env perl
+# Copyright 2010-2011 Microsoft Corporation
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+# WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+# MERCHANTABLITY OR NON-INFRINGEMENT.
+# See the Apache 2 License for the specific language governing permissions and
+# limitations under the License.
+
+# converts an utt2spk file to a spk2utt file.
+# Takes input from the stdin or from a file argument;
+# output goes to the standard out.
+
+if ( @ARGV > 1 ) {
+    die "Usage: utt2spk_to_spk2utt.pl [ utt2spk ] > spk2utt";
+}
+
+while(<>){ 
+    @A = split(" ", $_);
+    @A == 2 || die "Invalid line in utt2spk file: $_";
+    ($u,$s) = @A;
+    if(!$seen_spk{$s}) {
+        $seen_spk{$s} = 1;
+        push @spklist, $s;
+    }
+    push (@{$spk_hash{$s}}, "$u");
+}
+foreach $s (@spklist) {
+    $l = join(' ',@{$spk_hash{$s}});
+    print "$s $l\n";
+}

--- a/server/scripts/vad.py
+++ b/server/scripts/vad.py
@@ -1,0 +1,57 @@
+from kaldi.util.table import SequentialMatrixReader, VectorWriter
+from kaldi.matrix import Vector
+from kaldi.util.table import SequentialMatrixReader
+from kaldi.ivector import compute_vad_energy, VadEnergyOptions
+from kaldi.util.options import ParseOptions
+
+
+def compute_vad(feat_rspecifier, vad_wspecifier):
+    try:
+        omit_unvoiced_utts = False
+
+        po = ParseOptions("")
+        opts = VadEnergyOptions()
+        opts.register(po)
+        po.read_config_file("/kaldigrpc/diarizer_model/src/vad.conf")
+
+        feat_reader = SequentialMatrixReader(feat_rspecifier)
+        vad_writer = VectorWriter(vad_wspecifier)
+
+        num_done = 0
+        num_err = 0
+        num_unvoiced = 0
+        tot_length = 0.0
+        tot_decision = 0.0
+
+        for utt, feat in feat_reader:
+            if (feat.num_rows == 0):
+                print("Warning: Empty feature matrix for utterance " + str(utt))
+                num_err += 1
+                continue
+
+            vad_result = Vector(feat.num_rows)
+            vad_result = compute_vad_energy(opts, feat)
+
+            sum = vad_result.sum()
+
+            if (sum == 0.0):
+                print("Warning: No frames were judged voiced for utterance " + str(utt))
+                num_unvoiced += 1
+            else:
+                num_done += 1
+
+            tot_decision += vad_result.sum()
+            tot_length += vad_result.dim
+
+            if not (omit_unvoiced_utts and sum == 0):
+                vad_writer.write(utt, vad_result)
+
+        print("Applied energy based voice activity detection; processed " + str(num_done) + " utterances successfully; " +
+            str(num_err) + " had empty features, and " + str(num_unvoiced) + " were completely unvoiced.")
+        print("Proportion of voiced frames was " + str((tot_decision /
+            tot_length)) + " over " + str(tot_length) + " frames.")
+
+        return 0 if num_done != 0 else 1
+    except Exception as e:
+        print(str(e))
+        return -1

--- a/server/scripts/xvectors.py
+++ b/server/scripts/xvectors.py
@@ -1,0 +1,386 @@
+import math
+import numpy as np
+
+from kaldi import nnet3, util
+from kaldi.util.table import MatrixWriter, SequentialMatrixReader, SequentialMatrixReader, SequentialVectorReader, RandomAccessVectorReader, IntWriter, VectorWriter
+from kaldi.nnet3 import (NnetComputer, ComputationRequest, IoSpecification, NnetComputeOptions,
+                         NnetSimpleComputationOptions, CachingOptimizingCompilerOptions, CachingOptimizingCompiler, CollapseModelConfig)
+from kaldi.cudamatrix import CuMatrix
+from kaldi.matrix import Vector, DoubleVector, Matrix, DoubleMatrix, SubMatrix, functions
+from kaldi.matrix.packed import DoubleSpMatrix
+from kaldi.matrix.common import MatrixTransposeType, MatrixResizeType
+from kaldi.nnet3._nnet_common import Index
+
+
+def extract_vectors(config, apply_cmn=True, window = None):
+    print("\nStarting x-vector extraction...")
+    feats_rspecifier = "ark:../diarizer_model/data/feats.ark"
+
+    # STAGE 0: Set up new xvector features if APPLY CMVN
+    if apply_cmn:
+        rspecifier = (
+            "ark:compute-mfcc-feats --config=/kaldigrpc/model/conf/mfcc.conf scp:/kaldigrpc/diarizer_model/data/wav2.scp ark:-"
+            " | apply-cmvn-sliding --norm-vars=false --cmn-window={} --center=true ark:- ark:-"
+            " | select-voiced-frames ark:- scp,s,cs:/kaldigrpc/diarizer_model/data/vad.scp ark:- |"
+        ).format(window)
+
+        with MatrixWriter("ark,scp:../diarizer_model/data/xvectors_cvmn_feats.ark,../diarizer_model/data/xvectors_cvmn_feats.scp") as writer:
+            for key, feats in SequentialMatrixReader(rspecifier):
+                writer[key] = feats
+
+            feats_rspecifier = "ark:../diarizer_model/data/xvectors_cmvn_feats.ark"
+
+    # STAGE 1: NNET3-xvector-compute
+    print("Extracting xvectors from nnet...")
+    NnetXvectorCompute(
+        config, feats_rspecifier, "ark,scp:../diarizer_model/data/xvectors.ark,../diarizer_model/data/xvectors.scp")
+
+    # STAGE 3: Computing mean of x-vectors
+    print("\nComputing mean of xvectors...")
+    iVectorMean("ark:/kaldigrpc/diarizer_model/data/xvectors.ark",
+                "/kaldigrpc/diarizer_model/data/mean.vec")
+
+    # STAGE 4: Computing whitening transform
+    if config.pca_dim is None:
+        config.pca_dim = -1
+    print("\nComputing whitening transform...")
+    estPca("ark:/kaldigrpc/diarizer_model/data/xvectors.ark",
+           "/kaldigrpc/diarizer_model/data/transform.mat", read_vectors=True, normalize_mean=False, normalize_variance=True, dim=config.pca_dim, binary=False)
+    print("X-vector extraction complete!")
+
+def NnetXvectorCompute(config, feature_rspecifier, vector_wspecifier):
+    opts = NnetSimpleComputationOptions()
+    compiler_config = CachingOptimizingCompilerOptions()
+
+    opts.acoustic_scale = 1.0  # by default do no scaling in this recipe.
+    chunk_size = -1
+    min_chunk_size = 100
+    pad_input = True
+
+    istream = util.io.Input(config.model_cfg.finalraw)
+    nnet = nnet3.Nnet().read(istream.stream(), binary=True)
+    istream2 = util.io.Input(config.model_cfg.extractconfig)
+    nnet.read_config(istream2.stream())
+
+    nnet3.set_batchnorm_test_mode(True, nnet)
+    nnet3.set_dropout_test_mode(True, nnet)
+    nnet3.collapse_model(CollapseModelConfig(), nnet)
+
+    compiler = CachingOptimizingCompiler.new_with_optimize_opts(
+        nnet, opts.optimize_config, compiler_config)
+
+    vector_writer = VectorWriter(vector_wspecifier)
+
+    num_success = 0
+    num_fail = 0
+    frame_count = 0
+    xvector_dim = nnet.output_dim("output")
+
+    feature_reader = SequentialMatrixReader(feature_rspecifier)
+    for utt, features in feature_reader:
+        if features.num_rows == 0:
+            print("Zero-length utterance: " + str(utt))
+            num_fail += 1
+
+        num_rows = features.num_rows
+        feat_dim = features.num_cols
+        this_chunk_size = chunk_size
+
+        if not pad_input and (num_rows < min_chunk_size):
+            print("Minimum chunk size of " + str(min_chunk_size) +
+                  " is greater than the number of rows in utterance: " + str(utt))
+            num_fail += 1
+        elif num_rows < chunk_size:
+            print("Chunk size of " + str(chunk_size) + " is greater than the number of rows in utterance: " +
+                  str(utt) + ", using chunk size  of " + str(num_rows))
+            this_chunk_size = num_rows
+        elif chunk_size == -1:
+            this_chunk_size = num_rows
+
+        num_chunks = math.ceil(num_rows / float(this_chunk_size))
+        xvector_avg = Vector(xvector_dim)
+        tot_weight = 0.0
+
+        # Iterate over the feature chunks.
+        for chunk_indx in range(0, num_chunks):
+            # If we're nearing the end of the input, we may need to shift the
+            # offset back so that we can get this_chunk_size frames of input to
+            # the nnet.
+            offset = int(min(this_chunk_size, num_rows -
+                         chunk_indx * this_chunk_size))
+            if not pad_input and (offset < min_chunk_size):
+                continue
+            sub_features = SubMatrix(
+                features, chunk_indx * this_chunk_size, offset, 0, feat_dim)
+            xvector = Vector()
+            tot_weight += offset
+
+            # Pad input if the offset is less than the minimum chunk size
+            if pad_input and (offset < min_chunk_size):
+                padded_features = Matrix(min_chunk_size, feat_dim)
+                left_context = int((min_chunk_size - offset) / 2)
+                right_context = int(min_chunk_size - offset - left_context)
+                for i in range(0, offset):
+                    padded_features.row(i).copy_(sub_features.row(0))
+                for i in range(0, right_context):
+                    padded_features.row(min_chunk_size - i - 1).copy_(sub_features.row(offset - 1))
+
+                padded_features.range(
+                    left_context, offset, 0, feat_dim).copy_(sub_features)
+                RunNnetComputation(padded_features, nnet, compiler, xvector)
+            else:
+                RunNnetComputation(sub_features, nnet, compiler, xvector)
+            xvector_avg.add_vec_(offset, xvector)
+
+        xvector_avg.scale_(1.0 / tot_weight)
+        vector_writer.write(utt, xvector_avg)
+
+        frame_count += features.num_rows
+        num_success += 1
+
+
+def iVectorMean(ivector_rspecifier, mean_wxfilename=None, spk2utt_rspecifier=None, num_utts_wspecifier=None, ivector_wspecifier=None):
+    # TODO Second part of if statement is not used/debugged yet
+    if(mean_wxfilename is not None):
+        num_done = 0
+        try:
+            ivector_reader = SequentialVectorReader(ivector_rspecifier)
+        except IOError:
+            exit(1)
+
+        sum = Vector()
+        for _, value in ivector_reader:
+            if (sum.dim == 0):
+                sum.resize_(value.shape[0])
+            sum.add_vec_(1.0, value)
+            num_done += 1
+
+        if (num_done == 0):
+            print("ERROR: No iVectors read")
+        else:
+            sum.scale_(1.0 / num_done)
+            istream = util.io.Output(mean_wxfilename, binary=False)
+            sum.write(istream.stream(), binary=False)
+
+            return 0
+    else:
+        spk_sumsq = 0.0
+        spk_sum = Vector()
+
+        num_spk_done = 0
+        num_spk_err = 0
+        num_utt_done = 0
+        num_utt_err = 0
+
+        ivector_reader = RandomAccessVectorReader(ivector_rspecifier)
+        spk2utt_reader = SequentialVectorReader(spk2utt_rspecifier)
+        ivector_writer = VectorWriter(ivector_wspecifier)
+        num_utts_writer = IntWriter(num_utts_wspecifier)
+
+        for spk, uttlist in spk2utt_reader:
+            if not uttlist:
+                print("Speaker with no utterances.")
+
+            spk_mean = Vector()
+            utt_count = 0
+            for i in uttlist:
+                utt = uttlist[i]
+                if not ivector_reader.has_key(utt):
+                    print("No iVector present in input for utterance " + str(utt))
+                    num_utt_err += 1
+                else:
+                    if utt_count == 0:
+                        spk_mean = ivector_reader.value(utt)
+                    else:
+                        spk_mean.add_vec_(1.0, ivector_reader.value(utt))
+
+                    num_utt_done += 1
+                    utt_count += 1
+
+            if utt_count == 0:
+                print("Not producing output for speaker " +
+                      str(spk) + " since no utterances had iVectors")
+                num_spk_err += 1
+            else:
+                spk_mean.scale(1.0 / utt_count)
+                ivector_writer.write(spk, spk_mean)
+                if num_utts_wspecifier != "":
+                    num_utts_writer.write(spk, utt_count)
+                num_spk_done += 1
+                spk_sumsq += functions.vec_vec(spk_mean, spk_mean)
+                if spk_sum.dim() == 0:
+                    spk_sum.resize(spk_mean.dim())
+                spk_sum.add_vec_(1.0, spk_mean)
+
+        print("Computed mean of " + str(num_spk_done) + " speakers ("
+              + str(num_spk_err) + " with no utterances), consisting of "
+              + str(num_utt_done) + " utterances (" + str(num_utt_err)
+              + " absent from input).")
+
+        if num_spk_done != 0:
+            spk_sumsq /= num_spk_done
+            spk_sum.scale(1.0 / num_spk_done)
+            mean_length = spk_sum.norm(2.0)
+            spk_length = math.sqrt(spk_sumsq)
+            norm_spk_length = spk_length / math.sqrt(spk_sum.dim())
+
+            print("Norm of mean of speakers is " + str(mean_length)
+                  + ", root-mean-square speaker-iVector length divided by "
+                  + "sqrt(dim) is " + str(norm_spk_length))
+
+        return 0 if num_spk_done != 0 else 1
+
+
+def estPca(rspecifier, pca_mat_wxfilename, binary=True, read_vectors=False, normalize_variance=False, normalize_mean=False, dim=-1, full_matrix_wxfilename=""):
+    num_done = 0
+    num_err = 0
+    count = 0
+    sum = DoubleVector()
+    sumsq = DoubleSpMatrix()
+
+    if not read_vectors:
+        feat_reader = SequentialMatrixReader(rspecifier)
+
+        for _ in feat_reader:
+            mat = Matrix(feat_reader.value())
+            if (mat.num_rows == 0):
+                print("Empty feature matrix")
+                num_err += 1
+                continue
+
+            if sum.dim() == 0:
+                sum.resize(mat.num_cols())
+                sumsq.resize(mat.num_cols())
+
+            if sum.dim() != mat.num_cols():
+                print("Feature dimension mismatch " +
+                      str(sum.Dim()) + " vs. " + str(mat.num_cols()))
+                num_err += 1
+                continue
+
+            sum.add_row_sum_mat_(1.0, mat)
+            sumsq.add_mat2_(1.0, mat, MatrixTransposeType.TRANS, 1.0)
+            count += mat.num_rows
+            num_done += 1
+
+        print("Accumulated stats from " + str(num_done) + " feature files, " +
+              str(num_err) + " with errors; " + str(count) + " frames.")
+    else:
+        vec_reader = SequentialVectorReader(rspecifier)
+
+        for _, value in vec_reader:
+            vec = DoubleVector(value)
+            if (vec.dim == 0):
+                print("Warning: Empty input vector")
+                num_err += 1
+                continue
+
+            if (sum.dim == 0):
+                sum.resize_(vec.dim)
+                sumsq.resize_(vec.dim)
+
+            if (sum.dim != vec.dim):
+                print("Warning: Feature dimension mismatch " +
+                      str(sum.dim) + " vs. " + str(vec.dim))
+                num_err += 1
+                continue
+
+            sum.add_vec_(1.0, vec)
+            sumsq.add_vec2_(1.0, vec)
+
+            count += 1.0
+            num_done += 1
+
+        print("Accumulated stats from " + str(num_done) +
+              " vectors, " + str(num_err) + " with errors.")
+
+    if num_done == 0:
+        print("Error: No data accumulated.")
+
+    sum.scale_(1.0 / count)
+    sumsq.scale_(1.0 / count)
+
+    sumsq.add_vec2_(-1, sum)  # now sumsq is centered covariance.
+
+    full_dim = sum.dim
+    if dim <= 0:
+        dim = full_dim
+    if dim > full_dim:
+        print("Final dimension " + str(dim) +
+              " is greater than feature " + "dimension " + str(full_dim))
+
+    # Instead of sumsq.Eig(&s, &P); and sort_svd:
+    sumsq = DoubleMatrix(sumsq)
+    u, s, _ = np.linalg.svd(sumsq)
+    s = DoubleVector(s)
+    P = DoubleMatrix(u)
+
+    print("Log: Eigenvalues in PCA are " + str(s))
+    print("Log: Sum of PCA eigenvalues is " + str(s.sum()) +
+          ", sum of kept eigenvalues is " + str(s.range(0, dim).sum()))
+
+    # Transpose of P.  This is what appears in the transform.
+    transform = P.transpose_()
+
+    if (normalize_variance):
+        for i in range(full_dim):
+            this_var = s[i]
+            min_var = 1.0e-15
+            if this_var < min_var:
+                print("Warning: --normalize-variance option: very tiny variance " +
+                      str(s[i]) + "encountered, treating as " + str(min_var))
+                this_var = min_var
+            # scale on features that will make the variance unit.
+            scale = 1.0 / math.sqrt(this_var)
+            transform.row(i).scale_(scale)
+
+    offset = DoubleVector(full_dim)
+
+    if (normalize_mean):
+        offset.add_mat_vec_(-1.0, transform,
+                            MatrixTransposeType.NO_TRANS, sum, 0.0)
+        # Add column to transform.
+        transform.resize_(full_dim, full_dim + 1, MatrixResizeType.COPY_DATA)
+        transform.copy_col_from_vec_(offset, full_dim)
+
+    transform_float = Matrix(transform)
+
+    if (full_matrix_wxfilename != ""):
+        istream = util.io.Output(full_matrix_wxfilename, binary)
+        transform_float.write(istream.stream(), binary)
+
+    transform_float.resize_(dim, transform_float.num_cols,
+                            MatrixResizeType.COPY_DATA)
+
+    istream = util.io.Output(pca_mat_wxfilename, binary)
+    transform_float.write(istream.stream(), binary)
+
+    return 0
+
+
+def RunNnetComputation(features, nnet, compiler, xvector):
+    request = ComputationRequest()
+    request.need_model_derivative = False
+    request.store_component_stats = False
+    request.inputs = [IoSpecification().from_interval(
+        "input", 0, features.num_rows)]
+
+    request.outputs = [IoSpecification().from_indexes(
+        "output", [Index()], False)]
+
+    # Note: compile() returns a NnetComputation object
+    computation = compiler.compile(request)
+    computer = NnetComputer(NnetComputeOptions(), computation, nnet, None)
+    input_feats_cu = CuMatrix().from_matrix(features)
+    computer.accept_input("input", input_feats_cu)
+    computer.run()
+
+    cu_output = CuMatrix
+    cu_output = computer.get_output_destructive("output")
+    xvector.resize_(cu_output.num_cols())
+
+    temp = Matrix(cu_output.num_rows(), cu_output.num_cols())
+    cu_output.copy_to_mat(temp)
+    xvector.copy_row_from_mat_(temp, 0)
+
+    return xvector


### PR DESCRIPTION
## Changes

### Kaldigrpc:
- Updated _config.py_ to include diarization configurations 
- Added _diarize.py_ to perform diarization on input audio files

### Scripts:
- Added _setup_diarizer.sh_  which downloads and configures pre-trained diarizer model files (Chime6)
- Added _split_wav.py_ which contains a method for extracting segments from a large audio file
- Added _utt2spk_to_spk2utt.pl_ which generates spk2utt file form utt2spk file
- Added _xvectors.py_ which contains methods for extracting x-vectors
- Added _plda.py_ which contains methods for PLDA scoring
- Added _cluster.py_ which contains methods for clustering speakers using PLDA scores
- Added _make_rttm.py_ whcih produces an rttm file 
- Added _vad.py_ which contains a method for computing vad energy using a features read specifier

## Test Usage

- Run the following scripts to download the pre-trained model's files and place them to the corresponding paths
```
cd server/scripts
./setup_chime6.sh
./setup_SAD.sh
./setup_diarizer.sh
```

- Build server 
`make build-server kaldi_model=<Your full path>/kaldi-grpc-server/server/chime6_model/ image_tag=kaldigrpc:chime6-latest`

- Run server by mounting your local directory which contains the .wav to be processed 
`docker run -p 50051:50051 -ti -v <local dir>:/tmp kaldigrpc:chime6-latest --port=50051 --max-workers=3`

- In another terminal list all running container ids
`docker ps`

- Copy the target container id and run an interactive shell to access the container's environment
`docker exec -it <container-id> bash`

- Run segmentation process  
```
cd /kaldigrpc
python segment.py --wav=/tmp/<your wav file>
```

- Or run the diarization process
`python diarize.py --wav=/tmp/<your wav file>`


### SAD results
You can find them in:
_/kaldigrpc/SAD_model/data/segments_
The format of the "segments" file is:
_\<utterance-id\> \<recording-id\> \<segment-begin\> \<segment-end\>_

### Diarization results
You can find them in:
_/kaldigrpc/diarizer_model/data/rttm_
The format of the "rttm" file is:
_SPEAKER \<recording-id\>  1 \<start time\>  \<duration\> NA NA \<speaker-id\> NA NA_


## Notes
If you want to perform only diarization there is no need to run separately SAD as it's already executed in it's initial stage. In case you want to inspect the SAD results for the diarization process, they can be found in:
_/kaldigrpc/diarizer_model/data/segments_

## TODO

- General cleanup and restructuring of the config file for the diarization class