### PR TITLE
added default beam value to makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ PYTHON=python
 
 max_workers=2
 server_port=50051
+beam=10
 
 all: depend generate-stubs
 


### PR DESCRIPTION
When using the Makefile make run-server command to run the server without setting a beam size with "beam=$(beam)", the server crashed. Added a default beam value in the Makefile. Not sure about what the value should be (i think when unspecified it defaults to 13).